### PR TITLE
Issue 26 - changes for remote execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ work
 /tmp
 **/*.egg-info
 **/.DS_Store
+*.retry

--- a/openshift/ansible/ansible.cfg
+++ b/openshift/ansible/ansible.cfg
@@ -1,2 +1,4 @@
 [defaults]
+callback_whitelist = profile_tasks
 inventory = inventory
+nocows = 1

--- a/openshift/ansible/roles/pipelines/files/post-service-descriptors.yaml
+++ b/openshift/ansible/roles/pipelines/files/post-service-descriptors.yaml
@@ -21,6 +21,8 @@ parameters:
   value: latest
 - name: POSTER_SA
   value: squonk
+- name: PULL_POLICY
+  value: Always
 
 objects:
 
@@ -42,5 +44,6 @@ objects:
         containers:
         - image: squonk/rdkit-pipelines-sdposter:${POSTER_IMAGE_TAG}
           name: pipelines-sd-poster
+          imagePullPolicy: ${PULL_POLICY}
 
         restartPolicy: Never

--- a/openshift/ansible/roles/pipelines/tasks/main.yaml
+++ b/openshift/ansible/roles/pipelines/tasks/main.yaml
@@ -21,7 +21,7 @@
   shell: oc delete jobs/{{ job_name }}
   when: jobs_result.stdout | regex_search('^%s' % job_name, multiline=True)
 
-- name: Run SD poster job (always)
+- name: Run SD poster job (always) (tag={{ oc_pipelines_sd_poster_image_tag }})
   shell: >
     oc process
     -f {{ role_path }}/files/post-service-descriptors.yaml

--- a/src/nextflow/docking/plip.config
+++ b/src/nextflow/docking/plip.config
@@ -1,4 +1,1 @@
-docker.enabled = true
-docker.mountFlags = 'z'
-docker.runOptions = '-u $(id -u):$(id -g)'
-process.container = 'informaticsmatters/pli:latest'
+// Intentionally Empty

--- a/src/nextflow/docking/plip.nsd.config
+++ b/src/nextflow/docking/plip.nsd.config
@@ -1,1 +1,1 @@
-process.container = 'informaticsmatters/pli:latest'
+// Intentionally Empty

--- a/src/nextflow/docking/plip.nsd.config
+++ b/src/nextflow/docking/plip.nsd.config
@@ -1,3 +1,1 @@
-docker.enabled = true
-docker.mountFlags = 'z'
 process.container = 'informaticsmatters/pli:latest'

--- a/src/nextflow/docking/plip.nsd.nf
+++ b/src/nextflow/docking/plip.nsd.nf
@@ -51,7 +51,7 @@ process joiner {
 
     container 'informaticsmatters/pli:latest'
     beforeScript 'chmod g+w .'
-    publishDir "$baseDir/results", mode: 'copy'
+    publishDir "$baseDir/results", mode: 'move'
 
     input:
     file parts from scored_parts.collect()

--- a/src/nextflow/docking/plip.nsd.nf
+++ b/src/nextflow/docking/plip.nsd.nf
@@ -51,7 +51,7 @@ process joiner {
 
     container 'informaticsmatters/pli:latest'
     beforeScript 'chmod g+w .'
-    publishDir "$baseDir/results", mode: 'symlink'
+    publishDir "$baseDir/results", mode: 'copy'
 
     input:
     file parts from scored_parts.collect()

--- a/src/nextflow/docking/plip.nsd.nf
+++ b/src/nextflow/docking/plip.nsd.nf
@@ -51,7 +51,7 @@ process joiner {
 
     container 'informaticsmatters/pli:latest'
     beforeScript 'chmod g+w .'
-    publishDir baseDir, mode: 'link'
+    publishDir "$baseDir/results", mode: 'symlink'
 
     input:
     file parts from scored_parts.collect()

--- a/src/nextflow/docking/plip.nsd.yml
+++ b/src/nextflow/docking/plip.nsd.yml
@@ -49,5 +49,5 @@ inputRoutes:
 - route: "FILE"
 outputRoutes:
 - route: "FILE"
-nextflowParams: >
+nextflowParams: |
   ${binding.variables.containsKey('score') ? 'params.score = ' + score : ''}

--- a/src/nextflow/docking/plip.nsd.yml
+++ b/src/nextflow/docking/plip.nsd.yml
@@ -49,4 +49,5 @@ inputRoutes:
 - route: "FILE"
 outputRoutes:
 - route: "FILE"
-nextflowParams: "${binding.variables.containsKey('score') ? ' --score ' + score: ''}"
+nextflowParams: >
+  ${binding.variables.containsKey('score') ? 'params.score = ' + score : ''}

--- a/src/nextflow/docking/rdock.config
+++ b/src/nextflow/docking/rdock.config
@@ -1,7 +1,1 @@
-docker.enabled = true
-// allow to run with SELinux
-docker.mountFlags = 'z'
-// this runs the containers as the current user
-docker.runOptions = '-u $(id -u):$(id -g)'
-// See here for information on this image: https://github.com/InformaticsMatters/rdock_docker
-process.container = 'informaticsmatters/rdock-mini:latest'
+// Intentionally Empty

--- a/src/nextflow/docking/rdock.nsd.config
+++ b/src/nextflow/docking/rdock.nsd.config
@@ -1,1 +1,1 @@
-process.container = 'informaticsmatters/rdkit_pipelines'
+// Intentionally Empty

--- a/src/nextflow/docking/rdock.nsd.config
+++ b/src/nextflow/docking/rdock.nsd.config
@@ -1,3 +1,1 @@
-docker.enabled = true
-docker.mountFlags = 'z'
 process.container = 'informaticsmatters/rdkit_pipelines'

--- a/src/nextflow/docking/rdock.nsd.nf
+++ b/src/nextflow/docking/rdock.nsd.nf
@@ -110,7 +110,7 @@ process metrics {
     beforeScript 'chmod g+w .'
     container 'informaticsmatters/rdkit_pipelines:latest'
 
-    publishDir baseDir, mode: 'link'
+    publishDir "$baseDir/results", mode: 'symlink'
 
     input:
     file 'results.sdf' from results

--- a/src/nextflow/docking/rdock.nsd.nf
+++ b/src/nextflow/docking/rdock.nsd.nf
@@ -110,7 +110,7 @@ process metrics {
     beforeScript 'chmod g+w .'
     container 'informaticsmatters/rdkit_pipelines:latest'
 
-    publishDir "$baseDir/results", mode: 'symlink'
+    publishDir "$baseDir/results", mode: 'copy'
 
     input:
     file 'results.sdf' from results

--- a/src/nextflow/docking/rdock.nsd.nf
+++ b/src/nextflow/docking/rdock.nsd.nf
@@ -110,7 +110,7 @@ process metrics {
     beforeScript 'chmod g+w .'
     container 'informaticsmatters/rdkit_pipelines:latest'
 
-    publishDir "$baseDir/results", mode: 'copy'
+    publishDir "$baseDir/results", mode: 'move'
 
     input:
     file 'results.sdf' from results

--- a/src/nextflow/docking/rdock.nsd.yml
+++ b/src/nextflow/docking/rdock.nsd.yml
@@ -86,4 +86,10 @@ inputRoutes:
 - route: "FILE"
 outputRoutes:
 - route: "FILE"
-nextflowParams: "--ligands ligands.data.gz --receptor config.zip --num_dockings $num --top $top${binding.variables.containsKey('score') ? ' --score ' + score: ''}${binding.variables.containsKey('nscore') ? ' --nscore ' + nscore: ''}"
+nextflowParams: >
+  params.ligands = ligands.data.gz \n
+  params.receptor = config.zip \n
+  params.num_dockings = $num \n
+  params.top = $top \n
+  ${binding.variables.containsKey('score') ? 'params.score = ' + score : ''} \n
+  ${binding.variables.containsKey('nscore') ? 'params.nscore = ' + nscore : ''}

--- a/src/nextflow/docking/rdock.nsd.yml
+++ b/src/nextflow/docking/rdock.nsd.yml
@@ -86,10 +86,10 @@ inputRoutes:
 - route: "FILE"
 outputRoutes:
 - route: "FILE"
-nextflowParams: >
-  params.ligands = ligands.data.gz \n
-  params.receptor = config.zip \n
-  params.num_dockings = $num \n
-  params.top = $top \n
-  ${binding.variables.containsKey('score') ? 'params.score = ' + score : ''} \n
+nextflowParams: |
+  params.ligands = ligands.data.gz
+  params.receptor = config.zip
+  params.num_dockings = $num
+  params.top = $top
+  ${binding.variables.containsKey('score') ? 'params.score = ' + score : ''}
   ${binding.variables.containsKey('nscore') ? 'params.nscore = ' + nscore : ''}

--- a/src/nextflow/docking/smog.config
+++ b/src/nextflow/docking/smog.config
@@ -1,4 +1,1 @@
-docker.enabled = true
-docker.mountFlags = 'z'
-docker.runOptions = '-u $(id -u):$(id -g)'
-process.container = 'informaticsmatters/smog:latest'
+// Intentionally Empty

--- a/src/nextflow/docking/smog.nsd.config
+++ b/src/nextflow/docking/smog.nsd.config
@@ -1,1 +1,1 @@
-process.container = 'informaticsmatters/smog:latest'
+// Intentionally Empty

--- a/src/nextflow/docking/smog.nsd.config
+++ b/src/nextflow/docking/smog.nsd.config
@@ -1,3 +1,1 @@
-docker.enabled = true
-docker.mountFlags = 'z'
 process.container = 'informaticsmatters/smog:latest'

--- a/src/nextflow/docking/smog.nsd.nf
+++ b/src/nextflow/docking/smog.nsd.nf
@@ -51,7 +51,7 @@ process joiner {
 
     container 'informaticsmatters/smog:latest'
     beforeScript 'chmod g+w .'
-    publishDir "$baseDir/results", mode: 'symlink'
+    publishDir "$baseDir/results", mode: 'copy'
 
     input:
     file parts from scored_parts.collect()

--- a/src/nextflow/docking/smog.nsd.nf
+++ b/src/nextflow/docking/smog.nsd.nf
@@ -51,7 +51,7 @@ process joiner {
 
     container 'informaticsmatters/smog:latest'
     beforeScript 'chmod g+w .'
-    publishDir baseDir, mode: 'link'
+    publishDir "$baseDir/results", mode: 'symlink'
 
     input:
     file parts from scored_parts.collect()

--- a/src/nextflow/docking/smog.nsd.nf
+++ b/src/nextflow/docking/smog.nsd.nf
@@ -51,7 +51,7 @@ process joiner {
 
     container 'informaticsmatters/smog:latest'
     beforeScript 'chmod g+w .'
-    publishDir "$baseDir/results", mode: 'copy'
+    publishDir "$baseDir/results", mode: 'move'
 
     input:
     file parts from scored_parts.collect()

--- a/src/nextflow/docking/smog.nsd.yml
+++ b/src/nextflow/docking/smog.nsd.yml
@@ -49,5 +49,5 @@ inputRoutes:
 - route: "FILE"
 outputRoutes:
 - route: "FILE"
-nextflowParams: >
+nextflowParams: |
   ${binding.variables.containsKey('score') ? 'params.score = ' + score : ''}

--- a/src/nextflow/docking/smog.nsd.yml
+++ b/src/nextflow/docking/smog.nsd.yml
@@ -49,4 +49,5 @@ inputRoutes:
 - route: "FILE"
 outputRoutes:
 - route: "FILE"
-nextflowParams: "${binding.variables.containsKey('score') ? ' --score ' + score: ''}"
+nextflowParams: >
+  ${binding.variables.containsKey('score') ? 'params.score = ' + score : ''}

--- a/src/nextflow/rdkit/screen-dataset.nsd.config
+++ b/src/nextflow/rdkit/screen-dataset.nsd.config
@@ -1,4 +1,1 @@
-docker.enabled = true
-docker.runOptions = '-u $(id -u):$(id -g)'
-docker.mountFlags = 'z'
 process.container = 'informaticsmatters/rdkit_pipelines'

--- a/src/nextflow/rdkit/screen-dataset.nsd.config
+++ b/src/nextflow/rdkit/screen-dataset.nsd.config
@@ -1,1 +1,1 @@
-process.container = 'informaticsmatters/rdkit_pipelines'
+// Intentionally Empty

--- a/src/nextflow/rdkit/screen-dataset.nsd.nf
+++ b/src/nextflow/rdkit/screen-dataset.nsd.nf
@@ -47,7 +47,7 @@ process joiner {
 
     container 'informaticsmatters/rdkit_pipelines:latest'
 
-    publishDir "$baseDir/results", mode: 'symlink'
+    publishDir "$baseDir/results", mode: 'copy'
 
     input:
     file 'splitter_metrics.txt' from splitter_metrics

--- a/src/nextflow/rdkit/screen-dataset.nsd.nf
+++ b/src/nextflow/rdkit/screen-dataset.nsd.nf
@@ -47,7 +47,7 @@ process joiner {
 
     container 'informaticsmatters/rdkit_pipelines:latest'
 
-    publishDir "$baseDir/results", mode: 'copy'
+    publishDir "$baseDir/results", mode: 'move'
 
     input:
     file 'splitter_metrics.txt' from splitter_metrics

--- a/src/nextflow/rdkit/screen-dataset.nsd.nf
+++ b/src/nextflow/rdkit/screen-dataset.nsd.nf
@@ -47,7 +47,7 @@ process joiner {
 
     container 'informaticsmatters/rdkit_pipelines:latest'
 
-    publishDir baseDir, mode: 'link'
+    publishDir "$baseDir/results", mode: 'symlink'
 
     input:
     file 'splitter_metrics.txt' from splitter_metrics

--- a/src/nextflow/rdkit/screen-dataset.nsd.yml
+++ b/src/nextflow/rdkit/screen-dataset.nsd.yml
@@ -95,4 +95,9 @@ inputRoutes:
 - route: "FILE"
 outputRoutes:
 - route: "FILE"
-nextflowParams: "--qsmiles \"$query_source\" --simmin $sim.minValue --simmax $sim.maxValue --descriptor $descriptor --metric $metric"
+nextflowParams: >
+  params.qsmiles = '$query_source' \n
+  params.simmin = $sim.minValue \n
+  params.simmax = $sim.maxValue \n
+  params.descriptor = '$descriptor' \n
+  params.metric = '$metric'

--- a/src/nextflow/rdkit/screen-dataset.nsd.yml
+++ b/src/nextflow/rdkit/screen-dataset.nsd.yml
@@ -95,9 +95,9 @@ inputRoutes:
 - route: "FILE"
 outputRoutes:
 - route: "FILE"
-nextflowParams: >
-  params.qsmiles = '$query_source' \n
-  params.simmin = $sim.minValue \n
-  params.simmax = $sim.maxValue \n
-  params.descriptor = '$descriptor' \n
+nextflowParams: |
+  params.qsmiles = '$query_source'
+  params.simmin = $sim.minValue
+  params.simmax = $sim.maxValue
+  params.descriptor = '$descriptor'
   params.metric = '$metric'

--- a/src/nextflow/rdkit/screen-multi-dataset.nsd.config
+++ b/src/nextflow/rdkit/screen-multi-dataset.nsd.config
@@ -1,4 +1,1 @@
-docker.enabled = true
-docker.runOptions = '-u $(id -u):$(id -g)'
-docker.mountFlags = 'z'
 process.container = 'informaticsmatters/rdkit_pipelines'

--- a/src/nextflow/rdkit/screen-multi-dataset.nsd.config
+++ b/src/nextflow/rdkit/screen-multi-dataset.nsd.config
@@ -1,1 +1,1 @@
-process.container = 'informaticsmatters/rdkit_pipelines'
+// Intentionally Empty

--- a/src/nextflow/rdkit/screen-multi-dataset.nsd.nf
+++ b/src/nextflow/rdkit/screen-multi-dataset.nsd.nf
@@ -49,7 +49,7 @@ process joiner {
 
     container 'informaticsmatters/rdkit_pipelines:latest'
 
-    publishDir "$baseDir/results", mode: 'symlink'
+    publishDir "$baseDir/results", mode: 'copy'
 
     input:
     file 'splitter_metrics.txt' from splitter_metrics

--- a/src/nextflow/rdkit/screen-multi-dataset.nsd.nf
+++ b/src/nextflow/rdkit/screen-multi-dataset.nsd.nf
@@ -49,7 +49,7 @@ process joiner {
 
     container 'informaticsmatters/rdkit_pipelines:latest'
 
-    publishDir "$baseDir/results", mode: 'copy'
+    publishDir "$baseDir/results", mode: 'move'
 
     input:
     file 'splitter_metrics.txt' from splitter_metrics

--- a/src/nextflow/rdkit/screen-multi-dataset.nsd.nf
+++ b/src/nextflow/rdkit/screen-multi-dataset.nsd.nf
@@ -49,7 +49,7 @@ process joiner {
 
     container 'informaticsmatters/rdkit_pipelines:latest'
 
-    publishDir baseDir, mode: 'link'
+    publishDir "$baseDir/results", mode: 'symlink'
 
     input:
     file 'splitter_metrics.txt' from splitter_metrics

--- a/src/nextflow/rdkit/screen-multi-dataset.nsd.yml
+++ b/src/nextflow/rdkit/screen-multi-dataset.nsd.yml
@@ -89,5 +89,8 @@ inputRoutes:
 - route: "FILE"
 outputRoutes:
 - route: "FILE"
-nextflowParams: "--simmin $sim.minValue --simmax $sim.maxValue --descriptor $descriptor --metric $metric"
-
+nextflowParams: >
+  params.simmin = $sim.minValue \n
+  params.simmax = $sim.maxValue \n
+  params.descriptor = '$descriptor' \n
+  params.metric = '$metric'

--- a/src/nextflow/rdkit/screen-multi-dataset.nsd.yml
+++ b/src/nextflow/rdkit/screen-multi-dataset.nsd.yml
@@ -90,7 +90,7 @@ inputRoutes:
 outputRoutes:
 - route: "FILE"
 nextflowParams: >
-  params.simmin = $sim.minValue \n
-  params.simmax = $sim.maxValue \n
-  params.descriptor = '$descriptor' \n
+  params.simmin = $sim.minValue
+  params.simmax = $sim.maxValue
+  params.descriptor = '$descriptor'
   params.metric = '$metric'

--- a/src/nextflow/rdkit/screen.config
+++ b/src/nextflow/rdkit/screen.config
@@ -1,4 +1,1 @@
-docker.enabled = true
-docker.runOptions = '-u $(id -u):$(id -g)'
-docker.mountFlags = 'z' // this is to allow to run when SELinux is enabled
-process.container = 'informaticsmatters/rdkit_pipelines'
+// Intentionally Empty


### PR DESCRIPTION
- Config files now empty (apart from comment)
- publishDir (where used) now `publishDir "$baseDir/results", mode: 'move'`
- nextflowParams now compliant with config-file needs
- Ansible config now generates timing info
- Ansible now sets container pullPolity to Always

Similarity tested in OpenSHift