### PR TITLE
Set van der Waals radius scale

### DIFF
--- a/src/python/pipelines/xchem/xcos.py
+++ b/src/python/pipelines/xchem/xcos.py
@@ -275,7 +275,8 @@ def getReverseScores(clustered_df, mols, frags, no_clustered_feats, rad_threshol
                 # NB reverse SuCOS scoring
                 fm_score = getFeatureMapScore(bit, frag_mol)
                 fm_score = np.clip(fm_score, 0, 1)
-                protrude_dist = rdShapeHelpers.ShapeProtrudeDist(bit, frag_mol, allowReordering=False)
+                # Change van der Waals radius scale for stricter overlay
+                protrude_dist = rdShapeHelpers.ShapeProtrudeDist(bit, frag_mol, allowReordering=False, vdwScale=0.2)
                 protrude_dist = np.clip(protrude_dist, 0, 1)
 
                 reverse_SuCOS_score = 0.5 * fm_score + 0.5 * (1 - protrude_dist)


### PR DESCRIPTION
Hi Tim,

As discussed, set the the van der Waals scale parameter to 0.2 (Default is 0.8) to be more selective when comparing shape overlays.